### PR TITLE
fix module name typo

### DIFF
--- a/express_router/app.js
+++ b/express_router/app.js
@@ -11,7 +11,7 @@ app.use(methodOverride('_method'));
 app.use(morgan('tiny'));
 
 // requiring routes middleware
-const instructorRoutes = require('./routes');
+const instructorRoutes = require('./router');
 app.use('/instructors', instructorRoutes);
 
 app.get('/', (req, res) => {


### PR DESCRIPTION
Currently, an error is thrown because of this typo.